### PR TITLE
feat: 同步多架构镜像和同步docker hub镜像到阿里云

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,3 +51,8 @@ images:
     - ingress-nginx/kube-webhook-certgen
   gcr.io:
     - kaniko-project/executor
+  docker.io:
+    - calico/cni
+    - calico/pod2daemon-flexvol
+    - calico/kube-controllers
+    - calico/node

--- a/sync.sh
+++ b/sync.sh
@@ -9,8 +9,8 @@ if [ -f sync.yaml ]; then
    echo "[Start] sync......."
    
    sudo skopeo login -u ${HUB_USERNAME} -p ${HUB_PASSWORD} ${hub} \
-   && sudo skopeo --insecure-policy sync --src yaml --dest docker sync.yaml $repo \
-   && sudo skopeo --insecure-policy sync --src yaml --dest docker custom_sync.yaml $repo
+   && sudo skopeo --insecure-policy sync -a --src yaml --dest docker sync.yaml $repo \
+   && sudo skopeo --insecure-policy sync -a --src yaml --dest docker custom_sync.yaml $repo
    
    echo "[End] done."
    


### PR DESCRIPTION
sync.sh只能同步执行action机器的架构镜像(amd64)，skopeo sync 有 -a 参数去支持同步多架构的镜像。在下载calico镜像的时候发现docker hub拉镜像很慢，因而增加增加了一个docker.io镜像的同步